### PR TITLE
symlink libbpf.so to path stored in ldconfig location.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,9 @@ DIR := $(CURDIR)/debian/libbpf0
 
 %:
 	dh $@ --sourcedirectory=src
-#override_dh_auto_install:
+override_dh_auto_install:
+	dh_auto_install
+	ln -sf ../lib64/libbpf.so.0.0.5 $(CURDIR)/debian/libbpf/usr/lib/libbpf.so
 #	dh_testdir
 #	dh_testroot
 #	dh_prep


### PR DESCRIPTION
ldconfig only has /usr/lib as library path libbpf is installed in lib64 so it should be symlinked in /usr/lib so suricata can pick up the shared library
